### PR TITLE
Add missing French translations

### DIFF
--- a/packages/actions/resources/lang/fr/delete.php
+++ b/packages/actions/resources/lang/fr/delete.php
@@ -49,11 +49,21 @@ return [
         ],
 
         'notifications' => [
-
             'deleted' => [
                 'title' => 'Supprimé(e)s',
             ],
 
+            'deleted_partial' => [
+                'title' => 'Supprimé :count sur :total',
+                'missing_authorization_failure_message' => "Vous n'avez pas l'autorisation de supprimer :count.",
+                'missing_processing_failure_message' => ":count n'a pas pu être supprimé.",
+            ],
+
+            'deleted_none' => [
+                'title' => 'Échec de la suppression',
+                'missing_authorization_failure_message' => "Vous n'avez pas l'autorisation de supprimer :count.",
+                'missing_processing_failure_message' => ":count n'a pas pu être supprimé.",
+            ],
         ],
 
     ],

--- a/packages/actions/resources/lang/fr/force-delete.php
+++ b/packages/actions/resources/lang/fr/force-delete.php
@@ -49,11 +49,21 @@ return [
         ],
 
         'notifications' => [
-
             'deleted' => [
                 'title' => 'Enregistrements supprimés',
             ],
 
+            'deleted_partial' => [
+                'title' => 'Supprimé :count sur :total',
+                'missing_authorization_failure_message' => "Vous n'avez pas l'autorisation de supprimer :count.",
+                'missing_processing_failure_message' => ":count n'a pas pu être supprimé.",
+            ],
+
+            'deleted_none' => [
+                'title' => 'Échec de la suppression',
+                'missing_authorization_failure_message' => "Vous n'avez pas l'autorisation de supprimer :count.",
+                'missing_processing_failure_message' => ":count n'a pas pu être supprimé.",
+            ],
         ],
 
     ],

--- a/packages/actions/resources/lang/fr/notifications.php
+++ b/packages/actions/resources/lang/fr/notifications.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'throttled' => [
+        'title' => 'Trop de tentatives',
+        'body' => 'Veuillez réessayer dans :seconds secondes.',
+    ],
+];

--- a/packages/actions/resources/lang/fr/restore.php
+++ b/packages/actions/resources/lang/fr/restore.php
@@ -49,11 +49,21 @@ return [
         ],
 
         'notifications' => [
-
             'restored' => [
                 'title' => 'Enregistrements restaurés',
             ],
 
+            'restored_partial' => [
+                'title' => 'Restauré :count sur :total',
+                'missing_authorization_failure_message' => "Vous n'avez pas l'autorisation de restaurer :count.",
+                'missing_processing_failure_message' => ":count n'a pas pu être restauré.",
+            ],
+
+            'restored_none' => [
+                'title' => 'Échec de la restauration',
+                'missing_authorization_failure_message' => "Vous n'avez pas l'autorisation de restaurer :count.",
+                'missing_processing_failure_message' => ":count n'a pas pu être restauré.",
+            ],
         ],
 
     ],

--- a/packages/forms/resources/lang/fr/components.php
+++ b/packages/forms/resources/lang/fr/components.php
@@ -279,6 +279,28 @@ return [
 
     ],
 
+    'modal_table_select' => [
+
+        'actions' => [
+
+            'select' => [
+
+                'label' => 'Sélectionner',
+
+                'actions' => [
+
+                    'select' => [
+                        'label' => 'Sélectionner',
+                    ],
+
+                ],
+
+            ],
+
+        ],
+
+    ],
+
     'radio' => [
 
         'boolean' => [
@@ -341,42 +363,84 @@ return [
     ],
 
     'rich_editor' => [
-
-        'dialogs' => [
-
-            'link' => [
-
-                'actions' => [
-                    'link' => 'Lien',
-                    'unlink' => 'Dissocier',
+        'actions' => [
+            'attach_files' => [
+                'label' => 'Téléverser un fichier',
+                'modal' => [
+                    'heading' => 'Téléverser un fichier',
+                    'form' => [
+                        'file' => [
+                            'label' => [
+                                'new' => 'Fichier',
+                                'existing' => 'Remplacer le fichier',
+                            ],
+                        ],
+                        'alt' => [
+                            'label' => [
+                                'new' => 'Texte alternatif',
+                                'existing' => 'Modifier le texte alternatif',
+                            ],
+                        ],
+                    ],
                 ],
-
-                'label' => 'URL',
-
-                'placeholder' => 'Entrez une URL',
-
             ],
-
+            'custom_block' => [
+                'modal' => [
+                    'actions' => [
+                        'insert' => [
+                            'label' => 'Insérer',
+                        ],
+                        'save' => [
+                            'label' => 'Enregistrer',
+                        ],
+                    ],
+                ],
+            ],
+            'link' => [
+                'label' => 'Modifier',
+                'modal' => [
+                    'heading' => 'Lien',
+                    'form' => [
+                        'url' => [
+                            'label' => 'URL',
+                        ],
+                        'should_open_in_new_tab' => [
+                            'label' => 'Ouvrir dans un nouvel onglet',
+                        ],
+                    ],
+                ],
+            ],
         ],
-
+        'no_merge_tag_search_results_message' => 'Aucun résultat pour ces champs de fusion.',
         'tools' => [
+            'align_center' => 'Aligner au centre',
+            'align_end' => 'Aligner à droite',
+            'align_justify' => 'Justifier',
+            'align_start' => 'Aligner à gauche',
             'attach_files' => 'Joindre fichiers',
             'blockquote' => 'Citation',
             'bold' => 'Gras',
             'bullet_list' => 'Liste à puces',
-            'code_block' => 'Code',
+            'code_block' => 'Bloc de code',
+            'custom_blocks' => 'Blocs',
             'h1' => 'Titre',
-            'h2' => 'Titre',
+            'h2' => 'En-tête',
             'h3' => 'Sous-titre',
+            'highlight' => 'Surligner',
+            'horizontal_rule' => 'Règle horizontale',
             'italic' => 'Italique',
+            'lead' => 'Texte introductif',
             'link' => 'Lien',
+            'merge_tags' => 'Champs de fusion',
             'ordered_list' => 'Liste numérotée',
             'redo' => 'Refaire',
+            'small' => 'Petit texte',
             'strike' => 'Barré',
+            'subscript' => 'Indice',
+            'superscript' => 'Exposant',
             'underline' => 'Souligné',
             'undo' => 'Annuler',
         ],
-
     ],
 
     'select' => [

--- a/packages/panels/resources/lang/fr/auth/http/controllers/block-email-change-verification-controller.php
+++ b/packages/panels/resources/lang/fr/auth/http/controllers/block-email-change-verification-controller.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    'notifications' => [
+        'blocked' => [
+            'title' => "Changement d'adresse e-mail bloqué",
+            'body' => "Vous avez bloqué avec succès une tentative de changement d'adresse e-mail vers :email. Si vous n'êtes pas à l'origine de la demande initiale, veuillez nous contacter immédiatement.",
+        ],
+
+        'failed' => [
+            'title' => "Échec du blocage du changement d'adresse e-mail",
+            'body' => "Malheureusement, vous n'avez pas pu empêcher le changement de l'adresse e-mail vers :email, car elle avait déjà été vérifiée avant le blocage. Si vous n'êtes pas à l'origine de la demande initiale, veuillez nous contacter immédiatement.",
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fr/auth/http/controllers/email-change-verification-controller.php
+++ b/packages/panels/resources/lang/fr/auth/http/controllers/email-change-verification-controller.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'notifications' => [
+        'verified' => [
+            'title' => 'Adresse e-mail modifiée',
+            'body' => 'Votre adresse e-mail a bien été modifiée en :email.',
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fr/auth/multi-factor/app/actions/disable.php
+++ b/packages/panels/resources/lang/fr/auth/multi-factor/app/actions/disable.php
@@ -1,0 +1,42 @@
+<?php
+
+return [
+    'label' => 'Désactiver',
+
+    'modal' => [
+        'heading' => "Désactiver l'application d'authentification",
+        'description' => "Êtes-vous sûr de vouloir arrêter d'utiliser l'application d'authentification ? La désactiver retirera une couche de sécurité supplémentaire de votre compte.",
+        'form' => [
+            'code' => [
+                'label' => "Saisissez le code à 6 chiffres de l'application",
+                'validation_attribute' => 'code',
+                'actions' => [
+                    'use_recovery_code' => [
+                        'label' => 'Utiliser plutôt un code de récupération',
+                    ],
+                ],
+                'messages' => [
+                    'invalid' => 'Le code saisi est invalide.',
+                ],
+            ],
+            'recovery_code' => [
+                'label' => 'Ou saisissez un code de récupération',
+                'validation_attribute' => 'code de récupération',
+                'messages' => [
+                    'invalid' => 'Le code de récupération saisi est invalide.',
+                ],
+            ],
+        ],
+        'actions' => [
+            'submit' => [
+                'label' => "Désactiver l'application d'authentification",
+            ],
+        ],
+    ],
+
+    'notifications' => [
+        'disabled' => [
+            'title' => "L'application d'authentification a été désactivée",
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fr/auth/multi-factor/app/actions/regenerate-recovery-codes.php
+++ b/packages/panels/resources/lang/fr/auth/multi-factor/app/actions/regenerate-recovery-codes.php
@@ -1,0 +1,46 @@
+<?php
+
+return [
+    'label' => 'Régénérer les codes de récupération',
+
+    'modal' => [
+        'heading' => "Régénérer les codes de récupération de l'application d'authentification",
+        'description' => 'Si vous perdez vos codes de récupération, vous pouvez les régénérer ici. Les anciens codes seront immédiatement invalidés.',
+        'form' => [
+            'code' => [
+                'label' => "Saisissez le code à 6 chiffres de l'application",
+                'validation_attribute' => 'code',
+                'messages' => [
+                    'invalid' => 'Le code saisi est invalide.',
+                ],
+            ],
+            'password' => [
+                'label' => 'Ou saisissez votre mot de passe actuel',
+                'validation_attribute' => 'mot de passe',
+            ],
+        ],
+        'actions' => [
+            'submit' => [
+                'label' => 'Régénérer les codes de récupération',
+            ],
+        ],
+    ],
+
+    'notifications' => [
+        'regenerated' => [
+            'title' => 'De nouveaux codes de récupération ont été générés',
+        ],
+    ],
+
+    'show_new_recovery_codes' => [
+        'modal' => [
+            'heading' => 'Nouveaux codes de récupération',
+            'description' => "Veuillez sauvegarder les codes de récupération suivants dans un endroit sûr. Ils ne seront affichés qu'une seule fois, mais vous en aurez besoin si vous perdez l'accès à votre application d'authentification :",
+            'actions' => [
+                'submit' => [
+                    'label' => 'Fermer',
+                ],
+            ],
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fr/auth/multi-factor/app/actions/set-up.php
+++ b/packages/panels/resources/lang/fr/auth/multi-factor/app/actions/set-up.php
@@ -1,0 +1,48 @@
+<?php
+
+return [
+    'label' => 'Configurer',
+
+    'modal' => [
+        'heading' => "Configurer l'application d'authentification",
+        'description' => <<<'BLADE'
+            Vous aurez besoin d'une application comme Google Authenticator (<x-filament::link href="https://itunes.apple.com/us/app/google-authenticator/id388497605" target="_blank">iOS</x-filament::link>, <x-filament::link href="https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2" target="_blank">Android</x-filament::link>) pour terminer ce processus.
+            BLADE,
+        'content' => [
+            'qr_code' => [
+                'instruction' => 'Scannez ce QR code avec votre application d\'authentification :',
+                'alt' => 'QR code à scanner avec une application d\'authentification',
+            ],
+            'text_code' => [
+                'instruction' => 'Ou saisissez ce code manuellement :',
+                'messages' => [
+                    'copied' => 'Copié',
+                ],
+            ],
+            'recovery_codes' => [
+                'instruction' => "Veuillez sauvegarder les codes de récupération suivants dans un endroit sûr. Ils ne seront affichés qu'une seule fois, mais vous en aurez besoin si vous perdez l'accès à votre application d'authentification :",
+            ],
+        ],
+        'form' => [
+            'code' => [
+                'label' => "Saisissez le code à 6 chiffres de l'application",
+                'validation_attribute' => 'code',
+                'below_content' => 'Vous devrez saisir ce code à 6 chiffres à chaque connexion ou action sensible.',
+                'messages' => [
+                    'invalid' => 'Le code saisi est invalide.',
+                ],
+            ],
+        ],
+        'actions' => [
+            'submit' => [
+                'label' => "Activer l'application d'authentification",
+            ],
+        ],
+    ],
+
+    'notifications' => [
+        'enabled' => [
+            'title' => "L'application d'authentification a été activée",
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fr/auth/multi-factor/app/provider.php
+++ b/packages/panels/resources/lang/fr/auth/multi-factor/app/provider.php
@@ -1,0 +1,37 @@
+<?php
+
+return [
+    'management_schema' => [
+        'actions' => [
+            'label' => "Application d'authentification",
+            'below_content' => 'Utilisez une application sécurisée pour générer un code temporaire afin de vérifier la connexion.',
+            'messages' => [
+                'enabled' => 'Activée',
+                'disabled' => 'Désactivée',
+            ],
+        ],
+    ],
+
+    'login_form' => [
+        'label' => "Utilisez un code de votre application d'authentification",
+        'code' => [
+            'label' => "Saisissez le code à 6 chiffres de l'application",
+            'validation_attribute' => 'code',
+            'actions' => [
+                'use_recovery_code' => [
+                    'label' => 'Utiliser plutôt un code de récupération',
+                ],
+            ],
+            'messages' => [
+                'invalid' => 'Le code saisi est invalide.',
+            ],
+        ],
+        'recovery_code' => [
+            'label' => 'Ou saisissez un code de récupération',
+            'validation_attribute' => 'code de récupération',
+            'messages' => [
+                'invalid' => 'Le code de récupération saisi est invalide.',
+            ],
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fr/auth/multi-factor/email/actions/disable.php
+++ b/packages/panels/resources/lang/fr/auth/multi-factor/email/actions/disable.php
@@ -1,0 +1,40 @@
+<?php
+
+return [
+    'label' => 'Désactiver',
+
+    'modal' => [
+        'heading' => 'Désactiver les codes de vérification par e-mail',
+        'description' => 'Êtes-vous sûr de vouloir arrêter de recevoir des codes de vérification par e-mail ? La désactivation retirera une couche de sécurité supplémentaire de votre compte.',
+        'form' => [
+            'code' => [
+                'label' => 'Saisissez le code à 6 chiffres que nous vous avons envoyé par e-mail',
+                'validation_attribute' => 'code',
+                'actions' => [
+                    'resend' => [
+                        'label' => 'Envoyer un nouveau code par e-mail',
+                        'notifications' => [
+                            'resent' => [
+                                'title' => 'Un nouveau code vous a été envoyé par e-mail',
+                            ],
+                        ],
+                    ],
+                ],
+                'messages' => [
+                    'invalid' => 'Le code saisi est invalide.',
+                ],
+            ],
+        ],
+        'actions' => [
+            'submit' => [
+                'label' => 'Désactiver les codes de vérification par e-mail',
+            ],
+        ],
+    ],
+
+    'notifications' => [
+        'disabled' => [
+            'title' => 'Les codes de vérification par e-mail ont été désactivés',
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fr/auth/multi-factor/email/actions/set-up.php
+++ b/packages/panels/resources/lang/fr/auth/multi-factor/email/actions/set-up.php
@@ -1,0 +1,40 @@
+<?php
+
+return [
+    'label' => 'Configurer',
+
+    'modal' => [
+        'heading' => 'Configurer les codes de vérification par e-mail',
+        'description' => 'Vous devrez saisir le code à 6 chiffres que nous vous enverrons par e-mail à chaque connexion ou action sensible. Vérifiez votre boîte mail pour un code de 6 chiffres afin de terminer la configuration.',
+        'form' => [
+            'code' => [
+                'label' => 'Saisissez le code à 6 chiffres que nous vous avons envoyé par e-mail',
+                'validation_attribute' => 'code',
+                'actions' => [
+                    'resend' => [
+                        'label' => 'Envoyer un nouveau code par e-mail',
+                        'notifications' => [
+                            'resent' => [
+                                'title' => 'Un nouveau code vous a été envoyé par e-mail',
+                            ],
+                        ],
+                    ],
+                ],
+                'messages' => [
+                    'invalid' => 'Le code saisi est invalide.',
+                ],
+            ],
+        ],
+        'actions' => [
+            'submit' => [
+                'label' => 'Activer les codes de vérification par e-mail',
+            ],
+        ],
+    ],
+
+    'notifications' => [
+        'enabled' => [
+            'title' => 'Les codes de vérification par e-mail ont été activés',
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fr/auth/multi-factor/email/notifications/verify-email-authentication.php
+++ b/packages/panels/resources/lang/fr/auth/multi-factor/email/notifications/verify-email-authentication.php
@@ -1,0 +1,10 @@
+<?php
+
+return [
+    'subject' => 'Voici votre code de connexion',
+
+    'lines' => [
+        'Votre code de connexion est : :code',
+        'Ce code expirera dans une minute.|Ce code expirera dans :minutes minutes.',
+    ],
+];

--- a/packages/panels/resources/lang/fr/auth/multi-factor/email/provider.php
+++ b/packages/panels/resources/lang/fr/auth/multi-factor/email/provider.php
@@ -1,0 +1,35 @@
+<?php
+
+return [
+    'management_schema' => [
+        'actions' => [
+            'label' => 'Codes de vérification par e-mail',
+            'below_content' => 'Recevez un code temporaire par e-mail pour vérifier votre identité lors de la connexion.',
+            'messages' => [
+                'enabled' => 'Activés',
+                'disabled' => 'Désactivés',
+            ],
+        ],
+    ],
+
+    'login_form' => [
+        'label' => 'Envoyer un code par e-mail',
+        'code' => [
+            'label' => 'Saisissez le code à 6 chiffres que nous vous avons envoyé par e-mail',
+            'validation_attribute' => 'code',
+            'actions' => [
+                'resend' => [
+                    'label' => 'Envoyer un nouveau code par e-mail',
+                    'notifications' => [
+                        'resent' => [
+                            'title' => 'Un nouveau code vous a été envoyé par e-mail',
+                        ],
+                    ],
+                ],
+            ],
+            'messages' => [
+                'invalid' => 'Le code saisi est invalide.',
+            ],
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fr/auth/multi-factor/pages/set-up-required-multi-factor-authentication.php
+++ b/packages/panels/resources/lang/fr/auth/multi-factor/pages/set-up-required-multi-factor-authentication.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'title' => "Configurer l'authentification à deux facteurs (2FA)",
+    'heading' => "Configurer l'authentification à deux facteurs",
+    'subheading' => 'La 2FA ajoute une couche de sécurité supplémentaire à votre compte en demandant une seconde vérification lors de la connexion.',
+    'actions' => [
+        'continue' => [
+            'label' => 'Continuer',
+        ],
+    ],
+];

--- a/packages/panels/resources/lang/fr/auth/multi-factor/recovery-codes-modal-content.php
+++ b/packages/panels/resources/lang/fr/auth/multi-factor/recovery-codes-modal-content.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+    'actions' => [
+        'Cliquez pour',
+        'copy' => [
+            'label' => 'copier',
+        ],
+        'ou',
+        'download' => [
+            'label' => 'télécharger',
+        ],
+        'tous les codes en une seule fois.',
+    ],
+
+    'messages' => [
+        'copied' => 'Copié',
+    ],
+];

--- a/packages/panels/resources/lang/fr/auth/notifications/notice-of-email-change-request.php
+++ b/packages/panels/resources/lang/fr/auth/notifications/notice-of-email-change-request.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+    'subject' => 'Votre adresse e-mail est en cours de modification',
+
+    'lines' => [
+        "Nous avons reçu une demande de modification de l'adresse e-mail associée à votre compte. Votre mot de passe a été utilisé pour confirmer ce changement.",
+        'Une fois vérifiée, la nouvelle adresse e-mail de votre compte sera : :email.',
+        "Vous pouvez bloquer ce changement avant qu'il ne soit vérifié en cliquant sur le bouton ci-dessous.",
+        "Si vous n'êtes pas à l'origine de cette demande, veuillez nous contacter immédiatement.",
+    ],
+
+    'action' => 'Bloquer la modification de l\'e-mail',
+];

--- a/packages/panels/resources/lang/fr/auth/pages/edit-profile.php
+++ b/packages/panels/resources/lang/fr/auth/pages/edit-profile.php
@@ -16,10 +16,18 @@ return [
 
         'password' => [
             'label' => 'Nouveau mot de passe',
+            'validation_attribute' => 'mot de passe',
         ],
 
         'password_confirmation' => [
             'label' => 'Confirmer le nouveau mot de passe',
+            'validation_attribute' => 'confirmation du mot de passe',
+        ],
+
+        'current_password' => [
+            'label' => 'Mot de passe actuel',
+            'below_content' => 'Pour des raisons de sécurité, veuillez confirmer votre mot de passe pour continuer.',
+            'validation_attribute' => 'mot de passe actuel',
         ],
 
         'actions' => [
@@ -32,7 +40,15 @@ return [
 
     ],
 
+    'multi_factor_authentication' => [
+        'label' => 'Authentification à deux facteurs (2FA)',
+    ],
+
     'notifications' => [
+        'email_change_verification_sent' => [
+            'title' => "Demande de changement d'adresse e-mail envoyée",
+            'body' => 'Une demande de modification de votre adresse e-mail a été envoyée à :email. Veuillez vérifier vos e-mails pour confirmer le changement.',
+        ],
 
         'saved' => [
             'title' => 'Sauvegardé',

--- a/packages/panels/resources/lang/fr/auth/pages/login.php
+++ b/packages/panels/resources/lang/fr/auth/pages/login.php
@@ -43,6 +43,21 @@ return [
 
     ],
 
+    'multi_factor' => [
+        'heading' => 'Vérifiez votre identité',
+        'subheading' => 'Pour continuer à vous connecter, vous devez vérifier votre identité.',
+        'form' => [
+            'provider' => [
+                'label' => 'Comment souhaitez-vous vérifier ?',
+            ],
+            'actions' => [
+                'authenticate' => [
+                    'label' => 'Confirmer la connexion',
+                ],
+            ],
+        ],
+    ],
+
     'messages' => [
 
         'failed' => 'Ces identifiants ne correspondent pas à nos enregistrements.',

--- a/packages/panels/resources/lang/fr/auth/pages/password-reset/request-password-reset.php
+++ b/packages/panels/resources/lang/fr/auth/pages/password-reset/request-password-reset.php
@@ -31,12 +31,13 @@ return [
     ],
 
     'notifications' => [
-
+        'sent' => [
+            'body' => "Si votre compte n'existe pas, vous ne recevrez pas l'email.",
+        ],
         'throttled' => [
             'title' => 'Trop de requêtes',
             'body' => 'Merci de réessayer dans :seconds secondes.',
         ],
-
     ],
 
 ];

--- a/packages/panels/resources/lang/fr/error-notifications.php
+++ b/packages/panels/resources/lang/fr/error-notifications.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'title' => 'Erreur lors du chargement de la page',
+    'body' => "Une erreur s'est produite lors du chargement de cette page. Veuillez réessayer plus tard.",
+];

--- a/packages/tables/resources/lang/fr/table.php
+++ b/packages/tables/resources/lang/fr/table.php
@@ -6,6 +6,12 @@ return [
 
         'heading' => 'Colonnes',
 
+        'actions' => [
+            'apply' => [
+                'label' => 'Appliquer les colonnes',
+            ],
+        ],
+
     ],
 
     'columns' => [
@@ -146,6 +152,9 @@ return [
 
         'select' => [
             'placeholder' => 'Tout',
+            'relationship' => [
+                'empty_option_label' => 'Aucun',
+            ],
         ],
 
         'trashed' => [
@@ -228,5 +237,7 @@ return [
         ],
 
     ],
+
+    'default_model_label' => 'enregistrement',
 
 ];

--- a/packages/widgets/resources/lang/fr/chart.php
+++ b/packages/widgets/resources/lang/fr/chart.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'actions' => [
+        'filter' => [
+            'label' => 'Filtrer',
+        ],
+    ],
+];


### PR DESCRIPTION
## Summary
- add missing French translations for panel auth flows and error notifications

## Testing
- `composer test:phpstan` *(fails: PHPStan process crashed due to memory limit)*
- `composer test:pest` *(fails: 2 tests failed)*
- `./vendor/bin/pint -v`

------
https://chatgpt.com/codex/tasks/task_e_685f094b2470832f8ba3dc90c8072689